### PR TITLE
setup.py: migrate away from distutils.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from os import path
-from distutils.core import setup
 import setuptools 
+from setuptools import setup
 
 
 this_directory = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
# Description
distutils is deprecated and going to be removed from Python 3.12. This change updates setup.py to make use of the setup function from setuptools instead, per [PyPA recommendations].

[PyPA recommendations]: https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html#prefer-setuptools

# Fixes  (issue)
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I have run the Debian package building procedure, then the test suite against the packaged result, and it shown no regressions.  Basically this can be replicated by installing the module and running the test suite against the installment.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
      _Change is one line, so adding comments around would probably be dead weight._
- [ ] ~~I have made corresponding changes to the documentation~~
      _Documentation didn't refer to distutils initially, no changes required I think._
- [x] My changes generate no new warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
      _There was no clear point, or way, for adding a test for this particular change._
- [x] New and existing unit tests pass locally with my changes
